### PR TITLE
Use correct pairing commitment

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -382,8 +382,9 @@ func (s *Server) pairSessions(ctx context.Context) error {
 				totalMessages += clients[i].pr.MessageCount
 			}
 			sid := s.sidPRNG.Next(32)
+			pairCommitment := []byte(commitment)
 			newm := func() Mixer {
-				mix, err := s.newm([]byte(commitment))
+				mix, err := s.newm(pairCommitment)
 				if err != nil {
 					// newm has been confirmed to not error with this input
 					log.Panicf("newm: %v", err)


### PR DESCRIPTION
This fixes a bug in the server where the closure used to generate a fresh
compatible mix was closing over a loop iterator.  This would cause reruns to
create coinjoins with invalid amounts.  These issues were being correctly
detected by dcrwallet, which would abort the mix for not finding a correct mixed
message of the correct value.