### PR TITLE
Increase client send deadline

### DIFF
--- a/dicemix.go
+++ b/dicemix.go
@@ -30,7 +30,7 @@ import (
 const MessageSize = 20
 
 const (
-	sendTimeout = time.Second
+	sendTimeout = 5 * time.Second
 	recvTimeout = 10 * time.Second
 )
 


### PR DESCRIPTION
The deadline was dropped late in development and is causing issues for
clients connecting over tor.  This bumps the send deadline back up to
what it was known to be working well with.