### PR TITLE
Double client read timeouts

### DIFF
--- a/dicemix.go
+++ b/dicemix.go
@@ -31,7 +31,7 @@ const MessageSize = 20
 
 const (
 	sendTimeout = 5 * time.Second
-	recvTimeout = 10 * time.Second
+	recvTimeout = 20 * time.Second
 )
 
 // GenConfirmer is a generator of fresh messages to mix in a DiceMix run and a


### PR DESCRIPTION
An issue was observed where a wallet successfully signed a mix and
responded to the server, but failed to read the resulting transaction
with all combined signatures.  It's suspected that this wallet was
faster to sign and respond to the mix, causing it to set an earlier
deadline than the server was able to respond within.  Doubling the
recv timeout should help.