### PR TITLE
Improve log clarity of received CM messages

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -685,9 +685,9 @@ func (s *session) doRun(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-s.allConfs:
-		log.Print("received all confirmations")
+		log.Print("received all CM messages")
 	case <-time.After(recvTimeout):
-		log.Print("confirmation timeout")
+		log.Print("CM timeout")
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
"received all confimations" was a misleading message due to all
received CM messages not necessarily containing the signatures to
confirm the mix, in which case the CM message would also indicate that
blame must be assigned.  Instead, log that all CM messages were
received.