### PR TITLE
Reconnect dcrd RPC client after client failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/jrick/wsrpc/v2 v2.0.0
+	github.com/jrick/wsrpc/v2 v2.1.4
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/jrick/wsrpc/v2 v2.0.0 h1:f0ACoYeSG0fUNpA42gPpDdZ/xzYLUxZjT1F4L+HLTgY=
-github.com/jrick/wsrpc/v2 v2.0.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
+github.com/jrick/wsrpc/v2 v2.1.4 h1:BxGaAQ9QQPanJzBLwQJUWGBF1fTZfrley0kPgbb2qvw=
+github.com/jrick/wsrpc/v2 v2.1.4/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
If the RPC client is put into an error state for any reason (e.g.
network loss), there must be a mechanism to reconnect without
destroying the server.  This change creates and caches a RPC client
from the main package, continuing to use it so long as it hasn't
failed.  After failure, a new client is created each time a new mix
object must be obtained by the server.

While here, update to latest wsrpc, which adds support for and enables
websocket ping/pong by default.

Closes #17.