### PR TITLE
Send BR rerun messages in a multi-case select

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -548,7 +548,10 @@ func (s *session) exclude(blamed []int) error {
 	s.rerunning = make(chan struct{})
 
 	for _, c := range s.clients {
-		c.out <- s.br
+		select {
+		case c.out <- s.br:
+		case <-c.done:
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This prevents a deadlock if the client has disconnected and the
channel can not be written.