### PR TITLE
Increase coinjoin RPC timeouts to 10s

### DIFF
--- a/coinjoin/coinjoin.go
+++ b/coinjoin/coinjoin.go
@@ -249,8 +249,10 @@ func (t *Tx) Join(unmixed []byte, pid int) error {
 	return nil
 }
 
+const rpcTimeout = 10 * time.Second
+
 func verifyOutput(c Caller, outpoint *wire.OutPoint, value int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
 	defer cancel()
 	var res struct {
 		Value float64 `json:"value"`
@@ -324,7 +326,7 @@ func (t *Tx) PublishMix(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 	err = t.c.Call(ctx, "sendrawtransaction", nil, b.String())
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/jrick/wsrpc/v2 v2.1.4
+	github.com/jrick/wsrpc/v2 v2.2.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/jrick/wsrpc/v2 v2.1.4 h1:BxGaAQ9QQPanJzBLwQJUWGBF1fTZfrley0kPgbb2qvw=
-github.com/jrick/wsrpc/v2 v2.1.4/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
+github.com/jrick/wsrpc/v2 v2.2.0 h1:6/vdMn8DhCg2gYedvZL2C44cyWv9JCw62tK3+9popMU=
+github.com/jrick/wsrpc/v2 v2.2.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
RPC calls performed by the coinjoin package (which verifies previous
outputs exist and submits transactions to dcrd) were being performed
with a 1s timeout.  This is possibly too short depending on the
network setup, so increase these to 10s.