### PR TITLE
Add error codes to server-sent messages

### DIFF
--- a/dicemix.go
+++ b/dicemix.go
@@ -138,6 +138,12 @@ func (c *client) recv(out interface{}, timeout time.Duration) error {
 		file = filepath.Base(file)
 		return fmt.Errorf("%v: read %T (%v:%v): %v", c.conn.LocalAddr(), out, file, line, err)
 	}
+	// Return server error if message carries an error code
+	if se, ok := out.(interface{ ServerError() error }); ok {
+		if err := se.ServerError(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
These error codes can provide more actionable information to a client
about the failed state of their mix, instead of simply being
disconnected from the server for an unknown reason and the client
seeing an EOF.

Currently two codes are defined: one for a catch-all server abort of
the session for an unspecified reason, and a second indicating that
the unmixed data submitted by the client (in a coinjoin, the tx
containing inputs and change outputs) is invalid.