### PR TITLE
Use io.ReadFull when reading from rand io.Reader.

### DIFF
--- a/x25519/kx.go
+++ b/x25519/kx.go
@@ -21,7 +21,7 @@ type KX struct {
 // key.
 func New(rand io.Reader) (*KX, error) {
 	kx := new(KX)
-	_, err := rand.Read(kx.Scalar[:])
+	_, err := io.ReadFull(rand, kx.Scalar[:])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When a reader is provided for cryptographically-secure randomness,
io.ReadFull should be preferred over the Read method so an error is
created if not all randomness could be provided.

This is only necessary when reading from a provided io.Reader rather
than calling crypto/rand.Read directly.