### PR TITLE
Remove license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ CoinShuffle++
 =============
 
 [![Build Status](https://github.com/decred/cspp/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/cspp/actions)
-[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/decred.org/cspp)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ CoinShuffle++
 ## Overview
 
 This module provides client and server implementations to execute the
-[CoinShuffle++](https://crypsys.mmci.uni-saarland.de/projects/FastDC/paper.pdf)
-mixing protocol.  While intended to be used to create Decred CoinJoin
-transactions, the client and server packages are generic enough to anonymously
-mix and join elements of any group.
+[CoinShuffle++](https://decred.org/research/ruffing2016.pdf) mixing protocol.
+While intended to be used to create Decred CoinJoin transactions, the client and
+server packages are generic enough to anonymously mix and join elements of any
+group.
 
 This implementation differs from the protocol described by the CoinShuffle++
 paper in the following ways:


### PR DESCRIPTION
The license is already mentioned at the bottom of the readme.

Furthermore, this badge linked to a site that has absolutely nothing
to do with the ISC license, making me unsure why it was being linked
at all to begin with.

I have nothing good nor bad to say regarding the content at this link,
but it's not relevant to our project in any way, and theoretically it
is possible for it to be promoting ideas we do not subscribe to.  Just
read the license itself instead (it's not long or complicated).