### PR TITLE
25519: use curve25519.X25519

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libflint-dev libmpfr-dev
       - name: Install linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/dcnet/dcnet.go
+++ b/dcnet/dcnet.go
@@ -252,7 +252,11 @@ func SharedKeys(kx *KX, ecdhPubs []*x25519.Public, cts []*PQCiphertext, sid []by
 			}
 
 			x25519Pub := ecdhPubs[peer]
-			sharedKey := kx.X25519.SharedKey(x25519Pub)
+			var sharedKey []byte
+			sharedKey, err = kx.X25519.SharedKey(x25519Pub)
+			if err != nil {
+				return
+			}
 			pqSharedKey, ok := sntrup4591761.Decapsulate(cts[peer], kx.PQSecret)
 			if ok != 1 {
 				err = fmt.Errorf("sntrup4591761: decapsulate failure")

--- a/x25519/kx_test.go
+++ b/x25519/kx_test.go
@@ -16,8 +16,14 @@ func TestKX(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shared0 := kx0.SharedKey(&kx1.Public)
-	shared1 := kx1.SharedKey(&kx0.Public)
+	shared0, err := kx0.SharedKey(&kx1.Public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared1, err := kx1.SharedKey(&kx0.Public)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(shared0, shared1) {
 		t.Fatal("non-agreement on shared key")
 	}


### PR DESCRIPTION
fixes warning:
when provided a low-order point, ScalarMult will set dst to all zeroes,
irrespective of the scalar. Instead, use the X25519 function, which will
return an error.