### PR TITLE
Validate revealed X25519 secret keys

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1162,6 +1162,12 @@ KELoop:
 		}
 		b[i].kx = make([]*x25519.KX, 0, s.mtot)
 		for j := range c.rs.ECDH {
+			if !x25519.ValidScalar(c.rs.ECDH[j]) {
+				log.Printf("blaming %v for bad X25519 scalar", c.raddr())
+				blamed = append(blamed, i)
+				continue KELoop
+			}
+
 			b[i].kx = append(b[i].kx, &x25519.KX{
 				Public: *c.ke.ECDH[j],
 				Scalar: *c.rs.ECDH[j],

--- a/x25519/kx.go
+++ b/x25519/kx.go
@@ -42,3 +42,8 @@ func (kx *KX) SharedKey(theirPublic *Public) []byte {
 	curve25519.ScalarMult(&sharedKey, (*[32]byte)(&kx.Scalar), (*[32]byte)(theirPublic))
 	return sharedKey[:]
 }
+
+// ValidScalar returns whether a secret X25519 scalar was properly constructed.
+func ValidScalar(s *Scalar) bool {
+	return s[0]&248 == s[0] && s[31]&127 == s[31] && s[31]|64 == s[31]
+}


### PR DESCRIPTION
When X25519 secret keys are revealed to the server, they must be
checked that they were properly constructed.  Any peers with invalid
keys are blamed.