### PR TITLE
Validate clients pay enough transaction fees

### DIFF
--- a/cmd/csppserver/server.go
+++ b/cmd/csppserver/server.go
@@ -63,6 +63,8 @@ var (
 	reportFlag   = fs.String("report", "", "report stats of successful mixes to file")
 )
 
+const minFeeRate int64 = 0.0001e8
+
 func main() {
 	fs.Parse(os.Args[1:])
 
@@ -142,7 +144,7 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
-		return coinjoin.NewTx(rpc, sc, amount, txVersion, lockTime, expiry)
+		return coinjoin.NewTx(rpc, sc, amount, minFeeRate, txVersion, lockTime, expiry)
 	}
 	s, err := server.New(cspp.MessageSize, newm, *epochFlag)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -57,7 +57,7 @@ type Mixer interface {
 // Joiner must be implemented by the Mixer when the server is used for CoinJoins.
 type Joiner interface {
 	Join(unmixed []byte, pid int) error
-	ValidateUnmixed(unmixed []byte) error
+	ValidateUnmixed(unmixed []byte, mcount int) error
 }
 
 // Shuffler shuffles all values (including non-anonymous) of a mix.
@@ -281,7 +281,7 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) error {
 		close(c.done)
 	}()
 	if j, ok := mix.(Joiner); ok {
-		err = j.ValidateUnmixed(pr.Unmixed)
+		err = j.ValidateUnmixed(pr.Unmixed, pr.MessageCount)
 		if err != nil {
 			c.sendDeadline(invalidUnmixed, sendTimeout)
 			return err


### PR DESCRIPTION
The server was not verifying that each client paid its fair share of
the transaction fee, as was intended (see README section about
submitted unmixed data).  This permitted a trivial DoS by including
change outputs which resulted in insufficient fee or invalid
transactions which produced more output value than they consumed.

An additional parameter for a client's mixed message count is added to
coinjoin.Tx.ValidateUnmixed.  This allows the method to determine the
total input and output value submitted by a single client, which will
now produce an error if insufficient fee is provided.

The integration tests have been updated to pass the new validation
rules.  Previously, these tests were producing transactions which
created more value than was spent, triggering the insufficient fee
checks.