### PR TITLE
Allow integration test message count to be increased

### DIFF
--- a/integration/honest_test.go
+++ b/integration/honest_test.go
@@ -33,9 +33,13 @@ func init() {
 var nFlag = flag.Int64("n", 3, "node count")
 var mFlag = flag.Int("m", 4, "message-per-node count")
 var epochFlag = flag.Duration("epoch", 5*time.Second, "mix epoch")
+var inputValue int64
+var inputValueJSON []byte
 
 func TestMain(m *testing.M) {
 	flag.Parse()
+	inputValue = int64(*mFlag) + 1
+	inputValueJSON = []byte(fmt.Sprintf(`{"value":%v}`, inputValue))
 	os.Exit(m.Run())
 }
 
@@ -126,7 +130,7 @@ type itJustWorks struct{}
 func (itJustWorks) Call(ctx context.Context, method string, res interface{}, args ...interface{}) error {
 	switch method {
 	case "gettxout":
-		return json.Unmarshal([]byte(`{"value":5.0}`), res)
+		return json.Unmarshal(inputValueJSON, res)
 	case "sendrawtransaction":
 		return nil
 	default:
@@ -191,7 +195,7 @@ func TestHonest(t *testing.T) {
 	for i := range peers {
 		i := i
 		go func() {
-			input := &wire.TxIn{ValueIn: 5e8}
+			input := &wire.TxIn{ValueIn: inputValue * 1e8}
 			change := &wire.TxOut{Value: 1e8 - int64(1+i)*0.001e8, PkScript: change}
 			con := newConfirmer(input, change)
 			conn, err := tls.Dial("tcp", s.Addr, nettest.ClientTLS)


### PR DESCRIPTION
It was not possible to increase the message count (using the -m flag
to the test) past the default value of 4 following the fee
verification, because the output being spent had a hardcoded value of
5 DCR.  Modify the spent output value to be 1 DCR greater than the
number of mixed messages so that additional messages can be added
without triggering the low fee checks.