### PR TITLE
Support similar LOGFLAGS as slog package

### DIFF
--- a/cmd/csppserver/log.go
+++ b/cmd/csppserver/log.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+func init() {
+	flags := log.LstdFlags | log.Lmicroseconds
+	for _, f := range strings.Split(os.Getenv("LOGFLAGS"), ",") {
+		switch f {
+		case "longfile":
+			flags |= log.Llongfile
+		case "shortfile":
+			flags |= log.Lshortfile
+		case "UTC":
+			flags |= log.LUTC
+		case "nodatetime":
+			flags &^= log.Ldate | log.Ltime | log.Lmicroseconds
+		}
+	}
+	log.SetFlags(flags)
+}

--- a/cmd/csppserver/server.go
+++ b/cmd/csppserver/server.go
@@ -29,10 +29,6 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-func init() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-}
-
 func defaultDcrdCA() string {
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
One use case of this would be LOGFLAGS=nodatetime in order to produce
log output which is suitable for sending to syslogd.