### PR TITLE
Add h2 to NextProtos

### DIFF
--- a/cmd/csppserver/server.go
+++ b/cmd/csppserver/server.go
@@ -210,7 +210,7 @@ func setupTLS() (tc *tls.Config, selfsignedCert []byte, alternateServerNames []s
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		},
-		NextProtos: []string{acme.ALPNProto},
+		NextProtos: []string{"h2", acme.ALPNProto},
 	}
 	tlsFlag := *tlsFlag
 	switch {


### PR DESCRIPTION
Go 1.17's crypto/tls package introduced strict ALPN checks.  When the
NextProtos field of a tls.Config is set, the client must provide a
matching protocol (with a http2 -> http/1.1 downgrade exception).

The missing "h2" protocol was preventing the TLS web server in
csppserver from browsers that provide their supported protocols.