### PR TITLE
Tag the signed KE messages

### DIFF
--- a/messages/messages.go
+++ b/messages/messages.go
@@ -275,6 +275,7 @@ type KE struct {
 
 func (ke *KE) WriteSigned(w io.Writer) {
 	scratch := make([]byte, 8)
+	w.Write(msgKE)
 	w.Write(putInt(scratch, ke.Run))
 	writeSignedByteSlice(w, scratch, ke.ECDH[:])
 	writeSignedByteSlice(w, scratch, ke.PQPK[:])


### PR DESCRIPTION
This is done to prevent KE signatures from acting as forged signatures
for other messages.