### PR TITLE
Sign big integers in a machine-independent way

### DIFF
--- a/messages/messages.go
+++ b/messages/messages.go
@@ -103,11 +103,11 @@ func putInt(scratch []byte, v int) []byte {
 }
 
 func writeSignedBigInt(w io.Writer, scratch []byte, bi *big.Int) {
-	bits := bi.Bits()
-	w.Write(putInt(scratch, len(bits)))
-	for i := range bits {
-		w.Write(putInt(scratch, int(bits[i])))
-	}
+	scratch[0] = byte(bi.Sign())
+	w.Write(scratch[:1])
+	b := bi.Bytes()
+	w.Write(putInt(scratch, len(b)))
+	w.Write(b)
 }
 
 func writeSlice(w io.Writer, scratch []byte, len int, write func(n int)) {


### PR DESCRIPTION
This fixes a protocol bug which caused signature validation failures
if the client and server used different sizes of the uint type, such
as a 32-bit client connecting to a 64-bit server.

While here, also commit to the signedness of the big.Int.

This fix is a protocol breaking change.