### PR TITLE
ci: Build on ubuntu-20.04 instead of latest.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Go CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [1.16, 1.17]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libflint-dev libmpfr-dev
       - name: Install linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
       - name: Build
         env:
           GO111MODULE: "on"


### PR DESCRIPTION
Using ubuntu-latest (22.04) leads to apt-get downloading libflint v2.8.4 which is incompatible with the current cspp code. Ubuntu 20.04 downloads v2.5.2 which works as expected.