### PR TITLE
Add -lgmp -lm to solver LDFLAGS

### DIFF
--- a/solver/solver.go
+++ b/solver/solver.go
@@ -2,7 +2,7 @@ package solver
 
 /*
 #cgo CFLAGS: -I/usr/local/include
-#cgo LDFLAGS: -L/usr/local/lib -lflint -lmpfr
+#cgo LDFLAGS: -L/usr/local/lib -lflint -lmpfr -lgmp -lm
 #include <stdlib.h>
 #include <flint/flint.h>
 #include <flint/fmpz_mod_poly.h>


### PR DESCRIPTION
This allows one to build an entirely static csppsolver executable, that can be distributed without needing libflint2 being installed, by building with:

go build -ldflags "-linkmode=external -extldflags=-static"

without needing to remember to add '-lgmp -lm' to the extldflags on the command line.