### PR TITLE
Replace solver.Roots with solverrpc.Roots

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,7 +24,7 @@ import (
 	"decred.org/cspp/v2/chacha20prng"
 	"decred.org/cspp/v2/dcnet"
 	"decred.org/cspp/v2/messages"
-	"decred.org/cspp/v2/solver"
+	"decred.org/cspp/v2/solverrpc"
 	"decred.org/cspp/v2/x25519"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/sync/errgroup"
@@ -785,7 +785,7 @@ func (s *session) doRun(ctx context.Context) (err error) {
 	powerSums := dcnet.AddVectors(vs...)
 	coeffs := dcnet.Coefficients(powerSums)
 	t := time.Now()
-	roots, err := solver.Roots(coeffs, dcnet.F)
+	roots, err := solverrpc.Roots(coeffs, dcnet.F)
 	if err != nil {
 		log.Printf("failed to solve roots: %v", err)
 		close(blaming)


### PR DESCRIPTION
This expects server deployments to have built a working csppsolver executable and it be placed in PATH.