### PR TITLE
Check and prevent duplicate tx inputs

### DIFF
--- a/integration/honest_test.go
+++ b/integration/honest_test.go
@@ -195,7 +195,12 @@ func TestHonest(t *testing.T) {
 	for i := range peers {
 		i := i
 		go func() {
-			input := &wire.TxIn{ValueIn: inputValue * 1e8}
+			input := &wire.TxIn{
+				ValueIn: inputValue * 1e8,
+				PreviousOutPoint: wire.OutPoint{
+					Index: uint32(i),
+				},
+			}
 			change := &wire.TxOut{Value: 1e8 - int64(1+i)*0.001e8, PkScript: change}
 			con := newConfirmer(input, change)
 			conn, err := tls.Dial("tcp", s.Addr, nettest.ClientTLS)

--- a/server/server.go
+++ b/server/server.go
@@ -684,6 +684,7 @@ func (s *session) doRun(ctx context.Context) (err error) {
 		if joiner, ok := s.mix.(Joiner); ok {
 			err := joiner.Join(c.pr.Unmixed, i)
 			if err != nil {
+				log.Printf("blaming %v for unmixed join error: %v", c.raddr(), err)
 				blamed = append(blamed, i)
 			}
 		} else if len(c.pr.Unmixed) != 0 {


### PR DESCRIPTION
If peers double spend, the error would occur during sendrawtransaction and cause a failed session with no blame assignment, but this could (and should) be caught earlier when joining the unmixed transactions.