### PR TITLE
Add included headers needed by flint 3.0.1

### DIFF
--- a/solver/solver.go
+++ b/solver/solver.go
@@ -5,7 +5,10 @@ package solver
 #cgo LDFLAGS: -L/usr/local/lib -lflint -lmpfr -lgmp -lm
 #include <stdlib.h>
 #include <flint/flint.h>
+#include <flint/fmpz.h>
+#include <flint/fmpz_mod.h>
 #include <flint/fmpz_mod_poly.h>
+#include <flint/fmpz_mod_poly_factor.h>
 */
 import "C"
 import (


### PR DESCRIPTION
Also replace the manually specified CFLAGS and LDFLAGS with ones returned by pkg-config.

There is a bug in flint's .pc file where -lflint is missing, so keep manually adding that flag.